### PR TITLE
Add child-node command in map service

### DIFF
--- a/src/app/modules/application/pages/application/application.component.ts
+++ b/src/app/modules/application/pages/application/application.component.ts
@@ -78,7 +78,11 @@ export class ApplicationComponent implements OnInit {
             this.mapCacheService.updateAttachedMap()
         })
 
-        this.mmpService.on('nodeCreate').subscribe(() => {
+        this.mmpService.on('nodeCreate').subscribe((node) => {
+            if (node) {
+                Object.assign(this.node, node)
+            }
+
             this.mapCacheService.updateAttachedMap()
         })
 


### PR DESCRIPTION
## Summary
- add a dedicated `addChildNode` command in the map service so callers can add children by parent id
- refactor node creation to reuse a helper that prepares branch colours based on parent data
- update the application page renderer to refresh its bound node details when a new node is created

## Testing
- `npm run lint` *(fails: existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68c851c1118c832baeb9e57a1c8e9c3d