### PR TITLE
Add ring shape drawing tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,4 @@
 ## Features in progress
 - Shape tools now include rings and ellipses that use a golden resize handle. Follow the same interaction pattern when you introduce more shapes.
 - Nodes and floating text boxes now store a `textSize` of `small`, `medium`, or `large`. Use the shared `normalizeTextSize` helper when adding new entry points that create or import these records.
+- The top toolbar is now collapsible; keep creation buttons available when collapsed and tuck detailed controls inside the expanded panel.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,4 @@
 - Nodes and floating text boxes now store a `textSize` of `small`, `medium`, or `large`. Use the shared `normalizeTextSize` helper when adding new entry points that create or import these records.
 - The top toolbar is now collapsible; keep creation buttons available when collapsed and tuck detailed controls inside the expanded panel.
 - The toolbar now has a single text editor that updates whichever node or text box is selected. Follow the `selectedTextTarget` pattern when wiring future text-based controls.
+- Double-clicking any node or floating text box should pop the toolbar open and move focus to the shared text editor so users can type right away.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,6 @@
 
 ## Style notes
 - Keep explanations and inline comments in clear, plain English so non-developers can follow along.
+
+## Features in progress
+- Shape tools now include rings and ellipses that use a golden resize handle. Follow the same interaction pattern when you introduce more shapes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@
 
 ## Features in progress
 - Shape tools now include rings and ellipses that use a golden resize handle. Follow the same interaction pattern when you introduce more shapes.
+- Nodes and floating text boxes now store a `textSize` of `small`, `medium`, or `large`. Use the shared `normalizeTextSize` helper when adding new entry points that create or import these records.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,4 @@
 - Shape tools now include rings and ellipses that use a golden resize handle. Follow the same interaction pattern when you introduce more shapes.
 - Nodes and floating text boxes now store a `textSize` of `small`, `medium`, or `large`. Use the shared `normalizeTextSize` helper when adding new entry points that create or import these records.
 - The top toolbar is now collapsible; keep creation buttons available when collapsed and tuck detailed controls inside the expanded panel.
+- The toolbar now has a single text editor that updates whichever node or text box is selected. Follow the `selectedTextTarget` pattern when wiring future text-based controls.

--- a/src/App.css
+++ b/src/App.css
@@ -137,13 +137,6 @@
   color: #e2e8f0;
 }
 
-.mindmap-toolbar__shape-hint {
-  margin: 0;
-  font-size: 0.78rem;
-  color: #cbd5f5;
-  line-height: 1.45;
-}
-
 .mindmap-toolbar__io-button {
   background: #38bdf8;
   color: #0f172a;

--- a/src/App.css
+++ b/src/App.css
@@ -77,6 +77,32 @@
   gap: 0.5rem;
 }
 
+.mindmap-toolbar__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.mindmap-toolbar__section-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #e2e8f0;
+}
+
+.mindmap-toolbar__shape-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.mindmap-toolbar__shape-hint {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #cbd5f5;
+  line-height: 1.4;
+}
+
 .mindmap-toolbar__io-button {
   background: #38bdf8;
   color: #0f172a;

--- a/src/App.css
+++ b/src/App.css
@@ -16,35 +16,42 @@
 
 .mindmap-toolbar {
   position: absolute;
-  top: 1.25rem;
-  left: 1.25rem;
+  top: 0.75rem;
+  left: 0.75rem;
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 0.85rem;
-  padding: 0.9rem 1rem;
-  border-radius: 1.25rem;
-  background: rgba(15, 23, 42, 0.78);
+  gap: 0.55rem;
+  padding: 0.65rem 0.75rem 0.75rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.72);
   color: #f8fafc;
   backdrop-filter: blur(12px);
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
+  width: min(26rem, calc(100vw - 2.5rem));
+  z-index: 5;
+}
+
+.mindmap-toolbar--collapsed {
+  padding-bottom: 0.6rem;
 }
 
 .mindmap-toolbar button {
-  padding: 0.45rem 1rem;
-  border-radius: 0.85rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 0.75rem;
   border: none;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   font-weight: 600;
   color: #0f172a;
   background: #facc15;
   cursor: pointer;
   transition: transform 120ms ease, box-shadow 120ms ease;
+  line-height: 1;
 }
 
 .mindmap-toolbar button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 6px 20px rgba(250, 204, 21, 0.35);
+  box-shadow: 0 6px 18px rgba(250, 204, 21, 0.35);
 }
 
 .mindmap-toolbar button:active {
@@ -59,48 +66,82 @@
   transform: none;
 }
 
-.mindmap-toolbar__row {
+.mindmap-toolbar button:focus-visible {
+  outline: 2px solid #facc15;
+  outline-offset: 2px;
+}
+
+.mindmap-toolbar__header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.mindmap-toolbar__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  flex: 1 1 auto;
+}
+
+.mindmap-toolbar__toggle {
+  background: rgba(148, 163, 184, 0.22);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  box-shadow: none;
+  padding: 0.3rem 0.65rem;
+  font-size: 0.85rem;
+}
+
+.mindmap-toolbar__toggle:hover {
+  transform: none;
+  box-shadow: none;
+  background: rgba(148, 163, 184, 0.32);
+}
+
+.mindmap-toolbar__toggle:active {
+  transform: none;
+}
+
+.mindmap-toolbar__row {
+  display: flex;
+  align-items: stretch;
+  gap: 0.65rem;
   width: 100%;
 }
 
 .mindmap-toolbar__row--editors {
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.mindmap-toolbar__body {
+  display: flex;
+  flex-direction: column;
   gap: 0.65rem;
 }
 
-.mindmap-toolbar__actions {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.mindmap-toolbar__section {
+.mindmap-toolbar__shape-panel {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.35rem;
 }
 
 .mindmap-toolbar__section-title {
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #e2e8f0;
 }
 
-.mindmap-toolbar__shape-actions {
-  display: flex;
-  gap: 0.5rem;
-}
-
 .mindmap-toolbar__shape-hint {
   margin: 0;
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   color: #cbd5f5;
-  line-height: 1.4;
+  line-height: 1.45;
 }
 
 .mindmap-toolbar__io-button {
@@ -168,36 +209,33 @@
 
 .mindmap-toolbar__text-editor {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.5rem 0.85rem;
-  border-radius: 9999px;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.45rem 0.7rem;
+  border-radius: 1rem;
   background: rgba(15, 23, 42, 0.55);
-  flex: 1 1 18rem;
-  flex-wrap: wrap;
 }
 
 .mindmap-toolbar__text-control {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  flex: 1 1 9rem;
+  gap: 0.3rem;
 }
 
 .mindmap-toolbar__text-label {
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   font-weight: 600;
   color: #e2e8f0;
 }
 
 .mindmap-toolbar__text-input {
   width: 100%;
-  padding: 0.35rem 0.75rem;
-  border-radius: 9999px;
+  padding: 0.32rem 0.65rem;
+  border-radius: 0.85rem;
   border: 1px solid rgba(148, 163, 184, 0.35);
   background: rgba(30, 41, 59, 0.9);
   color: #f8fafc;
-  font-size: 0.95rem;
+  font-size: 0.92rem;
 }
 
 .mindmap-toolbar__text-input:focus {
@@ -214,12 +252,12 @@
 
 .mindmap-toolbar__text-select {
   width: 100%;
-  padding: 0.35rem 0.75rem;
-  border-radius: 9999px;
+  padding: 0.32rem 0.65rem;
+  border-radius: 0.85rem;
   border: 1px solid rgba(148, 163, 184, 0.35);
   background: rgba(30, 41, 59, 0.9);
   color: #f8fafc;
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   appearance: none;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -169,21 +169,29 @@
 .mindmap-toolbar__text-editor {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem 0.75rem;
+  gap: 0.75rem;
+  padding: 0.5rem 0.85rem;
   border-radius: 9999px;
   background: rgba(15, 23, 42, 0.55);
-  flex: 1 1 16rem;
+  flex: 1 1 18rem;
+  flex-wrap: wrap;
 }
 
-.mindmap-toolbar__text-editor span {
+.mindmap-toolbar__text-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  flex: 1 1 9rem;
+}
+
+.mindmap-toolbar__text-label {
   font-size: 0.85rem;
   font-weight: 600;
   color: #e2e8f0;
 }
 
 .mindmap-toolbar__text-input {
-  width: 14rem;
+  width: 100%;
   padding: 0.35rem 0.75rem;
   border-radius: 9999px;
   border: 1px solid rgba(148, 163, 184, 0.35);
@@ -199,6 +207,29 @@
 }
 
 .mindmap-toolbar__text-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.mindmap-toolbar__text-select {
+  width: 100%;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.9);
+  color: #f8fafc;
+  font-size: 0.95rem;
+  appearance: none;
+}
+
+.mindmap-toolbar__text-select:focus {
+  outline: none;
+  border-color: #facc15;
+  box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.4);
+}
+
+.mindmap-toolbar__text-select:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   box-shadow: none;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,9 +14,9 @@ import './App.css'
 const NODE_BASE_RADIUS = 40
 const NODE_TEXT_PADDING = 18
 const NODE_FONT_SIZES: Record<TextSize, number> = {
-  small: 14,
-  medium: 16,
-  large: 20,
+  small: 13,
+  medium: 18,
+  large: 24,
 }
 const LINK_DISTANCE = 160
 const FALLBACK_COLORS = ['#22d3ee', '#a855f7', '#10b981', '#f97316', '#facc15']
@@ -26,14 +26,14 @@ const ZOOM_STEP = 1.2
 const KEYBOARD_PAN_STEP = 80
 const AUTO_CENTER_PADDING = 160
 const ANNOTATION_FONT_SIZES: Record<TextSize, number> = {
-  small: 16,
-  medium: 18,
-  large: 22,
+  small: 15,
+  medium: 21,
+  large: 28,
 }
 const ANNOTATION_LINE_HEIGHTS: Record<TextSize, number> = {
-  small: 22,
-  medium: 26,
-  large: 30,
+  small: 24,
+  medium: 30,
+  large: 38,
 }
 const ANNOTATION_PADDING_X = 14
 const ANNOTATION_PADDING_Y = 10
@@ -229,6 +229,7 @@ export default function App() {
   const hasAutoCenteredRef = useRef(false)
   const exportMenuRef = useRef<HTMLDivElement | null>(null)
   const [isExportMenuOpen, setExportMenuOpen] = useState(false)
+  const [isToolbarCollapsed, setToolbarCollapsed] = useState(false)
 
   const getNodeRadius = useCallback(
     (node: MindMapNode) => {
@@ -302,6 +303,10 @@ export default function App() {
 
   const toggleExportMenu = useCallback(() => {
     setExportMenuOpen((previous) => !previous)
+  }, [])
+
+  const toggleToolbarCollapsed = useCallback(() => {
+    setToolbarCollapsed((previous) => !previous)
   }, [])
 
   const drawScene = useCallback(() => {
@@ -1658,21 +1663,32 @@ export default function App() {
     [dispatch, selectedAnnotationId],
   )
 
+  const toolbarBodyId = 'mindmap-toolbar-body'
+  const toolbarClassName = `mindmap-toolbar${isToolbarCollapsed ? ' mindmap-toolbar--collapsed' : ''}`
+
   return (
     <div className="app-shell">
       <canvas ref={canvasRef} className="mindmap-canvas" />
-      <div className="mindmap-toolbar">
-        <div className="mindmap-toolbar__actions">
-          <button type="button" onClick={handleAddChild} title="Enter">
-            Add child
+      <div className={toolbarClassName}>
+        <div className="mindmap-toolbar__header">
+          <button
+            type="button"
+            onClick={toggleToolbarCollapsed}
+            className="mindmap-toolbar__toggle"
+            aria-expanded={!isToolbarCollapsed}
+            aria-controls={toolbarBodyId}
+            aria-label="Toggle toolbar visibility"
+            title={isToolbarCollapsed ? 'Show toolbar controls' : 'Hide toolbar controls'}
+          >
+            {isToolbarCollapsed ? 'Show tools ▼' : 'Hide tools ▲'}
           </button>
-          <button type="button" onClick={handleAddAnnotation} title="Add a floating text note">
-            Add text
-          </button>
-        </div>
-        <div className="mindmap-toolbar__section" aria-label="Shape tools">
-          <span className="mindmap-toolbar__section-title">Shapes</span>
-          <div className="mindmap-toolbar__shape-actions">
+          <div className="mindmap-toolbar__header-actions">
+            <button type="button" onClick={handleAddChild} title="Enter">
+              Add child
+            </button>
+            <button type="button" onClick={handleAddAnnotation} title="Add a floating text note">
+              Add text
+            </button>
             <button type="button" onClick={handleAddRing} title="Add a ring to group related ideas">
               Add ring
             </button>
@@ -1684,80 +1700,87 @@ export default function App() {
               Add ellipse
             </button>
           </div>
-          <p className="mindmap-toolbar__shape-hint" aria-live="polite">
-            {selectedRing
-              ? `Ring radius: ${Math.round(selectedRing.radius)} px. Drag the golden square on the ring to resize it.`
-              : selectedEllipse
-              ? `Ellipse size: ${Math.round(selectedEllipse.radiusX * 2)} × ${Math.round(selectedEllipse.radiusY * 2)} px. Drag the golden square on the lower right to stretch it.`
-              : 'Add a ring or ellipse to highlight related thoughts. Select the shape and drag the golden square handle to resize it.'}
-          </p>
         </div>
-        <div className="mindmap-toolbar__row mindmap-toolbar__row--editors">
-          <div className="mindmap-toolbar__text-editor">
-            <label className="mindmap-toolbar__text-control">
-              <span className="mindmap-toolbar__text-label">Edit node</span>
-              <input
-                type="text"
-                value={editText}
-                onChange={handleNodeTextChange}
-                placeholder={selectedNode ? 'Type here to rename the node' : 'Select a node first'}
-                disabled={!selectedNode}
-                aria-label="Selected node text"
-                className="mindmap-toolbar__text-input"
-                ref={nodeInputRef}
-              />
-            </label>
-            <label className="mindmap-toolbar__text-control">
-              <span className="mindmap-toolbar__text-label">Text size</span>
-              <select
-                value={selectedNodeTextSize}
-                onChange={handleNodeTextSizeChange}
-                disabled={!selectedNode}
-                aria-label="Selected node text size"
-                className="mindmap-toolbar__text-select"
-              >
-                {TEXT_SIZE_CHOICES.map((size) => (
-                  <option key={size} value={size}>
-                    {TEXT_SIZE_LABELS[size]}
-                  </option>
-                ))}
-              </select>
-            </label>
+        {!isToolbarCollapsed ? (
+          <div className="mindmap-toolbar__body" id={toolbarBodyId}>
+            <div className="mindmap-toolbar__shape-panel">
+              <span className="mindmap-toolbar__section-title">Shapes</span>
+              <p className="mindmap-toolbar__shape-hint" aria-live="polite">
+                {selectedRing
+                  ? `Ring radius: ${Math.round(selectedRing.radius)} px. Drag the golden square on the ring to resize it.`
+                  : selectedEllipse
+                  ? `Ellipse size: ${Math.round(selectedEllipse.radiusX * 2)} × ${Math.round(selectedEllipse.radiusY * 2)} px. Drag the golden square on the lower right to stretch it.`
+                  : 'Add a ring or ellipse to highlight related thoughts. Select the shape and drag the golden square handle to resize it.'}
+              </p>
+            </div>
+            <div className="mindmap-toolbar__row mindmap-toolbar__row--editors">
+              <div className="mindmap-toolbar__text-editor">
+                <label className="mindmap-toolbar__text-control">
+                  <span className="mindmap-toolbar__text-label">Edit node</span>
+                  <input
+                    type="text"
+                    value={editText}
+                    onChange={handleNodeTextChange}
+                    placeholder={selectedNode ? 'Type here to rename the node' : 'Select a node first'}
+                    disabled={!selectedNode}
+                    aria-label="Selected node text"
+                    className="mindmap-toolbar__text-input"
+                    ref={nodeInputRef}
+                  />
+                </label>
+                <label className="mindmap-toolbar__text-control">
+                  <span className="mindmap-toolbar__text-label">Text size</span>
+                  <select
+                    value={selectedNodeTextSize}
+                    onChange={handleNodeTextSizeChange}
+                    disabled={!selectedNode}
+                    aria-label="Selected node text size"
+                    className="mindmap-toolbar__text-select"
+                  >
+                    {TEXT_SIZE_CHOICES.map((size) => (
+                      <option key={size} value={size}>
+                        {TEXT_SIZE_LABELS[size]}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              <div className="mindmap-toolbar__text-editor">
+                <label className="mindmap-toolbar__text-control">
+                  <span className="mindmap-toolbar__text-label">Edit text</span>
+                  <input
+                    type="text"
+                    value={annotationEditText}
+                    onChange={handleAnnotationTextChange}
+                    placeholder={
+                      selectedAnnotation ? 'Type here to update the text box' : 'Select a text box first'
+                    }
+                    disabled={!selectedAnnotation}
+                    aria-label="Selected text box content"
+                    className="mindmap-toolbar__text-input"
+                    ref={annotationInputRef}
+                  />
+                </label>
+                <label className="mindmap-toolbar__text-control">
+                  <span className="mindmap-toolbar__text-label">Text size</span>
+                  <select
+                    value={selectedAnnotationTextSize}
+                    onChange={handleAnnotationTextSizeChange}
+                    disabled={!selectedAnnotation}
+                    aria-label="Selected text box size"
+                    className="mindmap-toolbar__text-select"
+                  >
+                    {TEXT_SIZE_CHOICES.map((size) => (
+                      <option key={size} value={size}>
+                        {TEXT_SIZE_LABELS[size]}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+            </div>
           </div>
-          <div className="mindmap-toolbar__text-editor">
-            <label className="mindmap-toolbar__text-control">
-              <span className="mindmap-toolbar__text-label">Edit text</span>
-              <input
-                type="text"
-                value={annotationEditText}
-                onChange={handleAnnotationTextChange}
-                placeholder={
-                  selectedAnnotation ? 'Type here to update the text box' : 'Select a text box first'
-                }
-                disabled={!selectedAnnotation}
-                aria-label="Selected text box content"
-                className="mindmap-toolbar__text-input"
-                ref={annotationInputRef}
-              />
-            </label>
-            <label className="mindmap-toolbar__text-control">
-              <span className="mindmap-toolbar__text-label">Text size</span>
-              <select
-                value={selectedAnnotationTextSize}
-                onChange={handleAnnotationTextSizeChange}
-                disabled={!selectedAnnotation}
-                aria-label="Selected text box size"
-                className="mindmap-toolbar__text-select"
-              >
-                {TEXT_SIZE_CHOICES.map((size) => (
-                  <option key={size} value={size}>
-                    {TEXT_SIZE_LABELS[size]}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
-        </div>
+        ) : null}
       </div>
       <div className="mindmap-io-panel">
         <button

--- a/src/state/MindMapContext.tsx
+++ b/src/state/MindMapContext.tsx
@@ -8,6 +8,16 @@ import {
   type Dispatch,
 } from 'react'
 
+export type TextSize = 'small' | 'medium' | 'large'
+
+export const TEXT_SIZE_CHOICES: readonly TextSize[] = ['small', 'medium', 'large']
+
+export function normalizeTextSize(value: unknown): TextSize {
+  return value === 'small' || value === 'medium' || value === 'large'
+    ? (value as TextSize)
+    : 'medium'
+}
+
 
 export interface MindMapNode {
   id: string
@@ -16,6 +26,7 @@ export interface MindMapNode {
   x: number
   y: number
   color: string
+  textSize: TextSize
 }
 
 export interface MindMapAnnotation {
@@ -23,6 +34,7 @@ export interface MindMapAnnotation {
   text: string
   x: number
   y: number
+  textSize: TextSize
 }
 
 export interface MindMapRing {
@@ -118,6 +130,7 @@ const initialState: MindMapState = {
       x: 0,
       y: 0,
       color: '#4f46e5',
+      textSize: 'medium',
     },
   ],
   annotations: [],
@@ -159,6 +172,10 @@ function isMindMapNode(value: unknown): value is MindMapNode {
     return false
   }
 
+  const normalizedSize = normalizeTextSize((node as { textSize?: unknown }).textSize)
+  const typedNode = node as { textSize: TextSize }
+  typedNode.textSize = normalizedSize
+
   return true
 }
 
@@ -179,6 +196,10 @@ function isMindMapAnnotation(value: unknown): value is MindMapAnnotation {
   if (typeof annotation.x !== 'number' || typeof annotation.y !== 'number') {
     return false
   }
+
+  const normalizedSize = normalizeTextSize((annotation as { textSize?: unknown }).textSize)
+  const typedAnnotation = annotation as { textSize: TextSize }
+  typedAnnotation.textSize = normalizedSize
 
   return true
 }
@@ -432,7 +453,8 @@ function mindMapReducer(state: MindMapState, action: MindMapAction): MindMapStat
         state.nodes[0]?.text !== 'Root' ||
         state.nodes[0]?.x !== 0 ||
         state.nodes[0]?.y !== 0 ||
-        state.nodes[0]?.color !== '#4f46e5'
+        state.nodes[0]?.color !== '#4f46e5' ||
+        state.nodes[0]?.textSize !== 'medium'
 
       const hasShapes = state.shapes.length > 0
 
@@ -447,6 +469,7 @@ function mindMapReducer(state: MindMapState, action: MindMapAction): MindMapStat
         x: 0,
         y: 0,
         color: '#4f46e5',
+        textSize: 'medium',
       }
 
       return commitState(state, {


### PR DESCRIPTION
## Summary
- add persistent shape state and selection handling for ring shapes
- render resizable rings on the canvas and expose an "Add ring" toolbar control
- include rings in JSON import/export flows and style the new shape controls

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb2ed69578832b999ace5dbeeed9b3