### PR TITLE
Restrict shape hit areas to their outlines

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -28,7 +28,7 @@
   color: #f8fafc;
   backdrop-filter: blur(12px);
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
-  width: min(26rem, calc(100vw - 2.5rem));
+  width: min(44rem, calc(100vw - 2.5rem));
   z-index: 5;
 }
 
@@ -47,6 +47,8 @@
   cursor: pointer;
   transition: transform 120ms ease, box-shadow 120ms ease;
   line-height: 1;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .mindmap-toolbar button.mindmap-toolbar__icon-button {
@@ -91,15 +93,16 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  overflow-x: auto;
 }
 
 .mindmap-toolbar__header-actions {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  flex-wrap: wrap;
-  flex: 1 1 auto;
+  flex-wrap: nowrap;
+  flex: 1 0 auto;
 }
 
 .mindmap-toolbar__toggle {

--- a/src/App.css
+++ b/src/App.css
@@ -49,6 +49,22 @@
   line-height: 1;
 }
 
+.mindmap-toolbar button.mindmap-toolbar__icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem;
+  width: 2.6rem;
+  height: 2.6rem;
+  min-width: 2.6rem;
+}
+
+.mindmap-toolbar__icon {
+  display: block;
+  width: 1.6rem;
+  height: 1.6rem;
+}
+
 .mindmap-toolbar button:hover {
   transform: translateY(-1px);
   box-shadow: 0 6px 18px rgba(250, 204, 21, 0.35);
@@ -135,6 +151,18 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #e2e8f0;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .mindmap-toolbar__io-button {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,12 +65,12 @@ const ARROW_DEFAULT_WIDTH = 340
 const ARROW_DEFAULT_HEIGHT = 180
 const ARROW_MIN_WIDTH = 36
 const ARROW_MIN_HEIGHT = 6
-const ARROW_DEFAULT_THICKNESS = 60
+const ARROW_DEFAULT_THICKNESS = 48
 const ARROW_MIN_THICKNESS = 2
 const ARROW_HIT_PADDING = 10
 const ARROW_DEFAULT_COLOR = '#f97316'
-const ARROW_HEAD_RATIO = 0.34
-const ARROW_MIN_HEAD_LENGTH = 14
+const ARROW_HEAD_RATIO = 0.6
+const ARROW_MIN_HEAD_LENGTH = 20
 const ARROW_MIN_SHAFT_HALF_HEIGHT = 1.2
 const ARROW_DEFAULT_ANGLE = 0
 const LINE_DEFAULT_LENGTH = 280
@@ -2506,10 +2506,7 @@ export default function App() {
               className="mindmap-toolbar__icon-button"
             >
               <svg viewBox="0 0 24 24" className="mindmap-toolbar__icon" aria-hidden="true">
-                <path
-                  d="M5 9.5h7l-2.2-2.4 1.6-1.6 5.8 6-5.8 6-1.6-1.6 2.2-2.4H5z"
-                  fill="#f97316"
-                />
+                <path d="M4.5 11h8V7.2L20 12l-7.5 4.8V13h-8z" fill="#f97316" />
               </svg>
               <span className="visually-hidden">Arrow</span>
             </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -821,10 +821,11 @@ export default function App() {
           if (shape.kind === 'ring') {
             const radius = Math.max(shape.radius, 0)
             const distance = Math.hypot(scenePoint.x - shape.x, scenePoint.y - shape.y)
-            const halfThickness = Math.max(1, shape.thickness / 2 + RING_HIT_PADDING)
-            const outerRadius = radius + halfThickness
+            const hitBand = Math.max(1, shape.thickness / 2 + RING_HIT_PADDING)
+            const outerRadius = radius + hitBand
+            const innerRadius = Math.max(0, radius - hitBand)
 
-            return distance <= outerRadius
+            return distance <= outerRadius && distance >= innerRadius
           }
 
           if (shape.kind === 'ellipse') {
@@ -832,13 +833,28 @@ export default function App() {
             const radiusY = Math.max(shape.radiusY, 1)
             const dx = scenePoint.x - shape.x
             const dy = scenePoint.y - shape.y
-            const outerRadiusX = radiusX + ELLIPSE_HIT_PADDING
-            const outerRadiusY = radiusY + ELLIPSE_HIT_PADDING
+            const hitBand = Math.max(1, shape.thickness / 2 + ELLIPSE_HIT_PADDING)
+            const outerRadiusX = radiusX + hitBand
+            const outerRadiusY = radiusY + hitBand
 
-            const normalized =
+            const outerNormalized =
               (dx * dx) / (outerRadiusX * outerRadiusX) + (dy * dy) / (outerRadiusY * outerRadiusY)
 
-            return Number.isFinite(normalized) && normalized <= 1
+            if (!Number.isFinite(outerNormalized) || outerNormalized > 1) {
+              return false
+            }
+
+            const innerRadiusX = radiusX - hitBand
+            const innerRadiusY = radiusY - hitBand
+
+            if (innerRadiusX <= 0 || innerRadiusY <= 0) {
+              return true
+            }
+
+            const innerNormalized =
+              (dx * dx) / (innerRadiusX * innerRadiusX) + (dy * dy) / (innerRadiusY * innerRadiusY)
+
+            return !Number.isFinite(innerNormalized) || innerNormalized >= 1
           }
 
           return false

--- a/src/state/MindMapContext.tsx
+++ b/src/state/MindMapContext.tsx
@@ -58,11 +58,35 @@ export interface MindMapEllipse {
   color: string
 }
 
-export type MindMapShape = MindMapRing | MindMapEllipse
+export interface MindMapRectangle {
+  id: string
+  kind: 'rectangle'
+  x: number
+  y: number
+  width: number
+  height: number
+  thickness: number
+  color: string
+}
+
+export interface MindMapArrow {
+  id: string
+  kind: 'arrow'
+  x: number
+  y: number
+  width: number
+  height: number
+  thickness: number
+  color: string
+}
+
+export type MindMapShape = MindMapRing | MindMapEllipse | MindMapRectangle | MindMapArrow
 
 type MindMapShapeUpdate =
   | Partial<Omit<MindMapRing, 'id' | 'kind'>>
   | Partial<Omit<MindMapEllipse, 'id' | 'kind'>>
+  | Partial<Omit<MindMapRectangle, 'id' | 'kind'>>
+  | Partial<Omit<MindMapArrow, 'id' | 'kind'>>
 
 interface MindMapSnapshot {
   nodes: MindMapNode[]
@@ -258,6 +282,64 @@ function isMindMapShape(value: unknown): value is MindMapShape {
       ellipse.radiusY > 0 &&
       Number.isFinite(ellipse.thickness) &&
       ellipse.thickness > 0
+    )
+  }
+
+  if (shape.kind === 'rectangle') {
+    const rectangle = shape as Partial<MindMapRectangle>
+
+    if (typeof rectangle.x !== 'number' || typeof rectangle.y !== 'number') {
+      return false
+    }
+
+    if (typeof rectangle.width !== 'number' || typeof rectangle.height !== 'number') {
+      return false
+    }
+
+    if (typeof rectangle.thickness !== 'number') {
+      return false
+    }
+
+    if (typeof rectangle.color !== 'string') {
+      return false
+    }
+
+    return (
+      Number.isFinite(rectangle.width) &&
+      Number.isFinite(rectangle.height) &&
+      rectangle.width > 0 &&
+      rectangle.height > 0 &&
+      Number.isFinite(rectangle.thickness) &&
+      rectangle.thickness > 0
+    )
+  }
+
+  if (shape.kind === 'arrow') {
+    const arrow = shape as Partial<MindMapArrow>
+
+    if (typeof arrow.x !== 'number' || typeof arrow.y !== 'number') {
+      return false
+    }
+
+    if (typeof arrow.width !== 'number' || typeof arrow.height !== 'number') {
+      return false
+    }
+
+    if (typeof arrow.thickness !== 'number') {
+      return false
+    }
+
+    if (typeof arrow.color !== 'string') {
+      return false
+    }
+
+    return (
+      Number.isFinite(arrow.width) &&
+      Number.isFinite(arrow.height) &&
+      arrow.width > 0 &&
+      arrow.height > 0 &&
+      Number.isFinite(arrow.thickness) &&
+      arrow.thickness > 0
     )
   }
 
@@ -549,8 +631,18 @@ function mindMapReducer(state: MindMapState, action: MindMapAction): MindMapStat
           return { ...shape, ...updates, id: shape.id, kind: 'ring' as const }
         }
 
-        const updates = action.updates as Partial<Omit<MindMapEllipse, 'id' | 'kind'>>
-        return { ...shape, ...updates, id: shape.id, kind: 'ellipse' as const }
+        if (shape.kind === 'ellipse') {
+          const updates = action.updates as Partial<Omit<MindMapEllipse, 'id' | 'kind'>>
+          return { ...shape, ...updates, id: shape.id, kind: 'ellipse' as const }
+        }
+
+        if (shape.kind === 'rectangle') {
+          const updates = action.updates as Partial<Omit<MindMapRectangle, 'id' | 'kind'>>
+          return { ...shape, ...updates, id: shape.id, kind: 'rectangle' as const }
+        }
+
+        const updates = action.updates as Partial<Omit<MindMapArrow, 'id' | 'kind'>>
+        return { ...shape, ...updates, id: shape.id, kind: 'arrow' as const }
       })
       return commitState(state, { shapes: nextShapes })
     }


### PR DESCRIPTION
## Summary
- limit ring hit testing to the stroke band so clicks inside the shape reach items underneath
- do the same for ellipses so large outlines no longer block inner content

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc371e05f8832ba5e659303a630938