### PR TITLE
Add ability to create standalone nodes

### DIFF
--- a/src/state/MindMapContext.tsx
+++ b/src/state/MindMapContext.tsx
@@ -161,7 +161,7 @@ interface MindMapContextValue {
 
 const MindMapContext = createContext<MindMapContextValue | undefined>(undefined)
 
-const ROOT_NODE_ID = 'root'
+export const ROOT_NODE_ID = 'root'
 
 const initialState: MindMapState = {
   nodes: [


### PR DESCRIPTION
## Summary
- add a toolbar action to drop a new standalone idea node at the current view center
- allow deleting standalone nodes while keeping the original root protected
- export the shared root node id constant so the UI and reducer stay in sync

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd74c4b2ec832b8c2736c325d9b49a