### PR TITLE
Add AGENTMAPS guide and example mindmap

### DIFF
--- a/AGENTMAPS/AGENTS.MD
+++ b/AGENTMAPS/AGENTS.MD
@@ -1,0 +1,50 @@
+# AGENTMAPS Guide for AI Assistants
+
+## Purpose
+- Capture mindmaps that teach or document workflows for this project.
+- Keep instructions friendly to non-coders and future agents.
+
+## Quick workflow
+1. Read `/AGENTS.md` at the repo root for global expectations (lint + build before commit).
+2. Skim existing maps in this folder so new work stays consistent.
+3. Agree with the user on the topic and the level of detail.
+4. Outline the map: pick one root idea, group related thoughts as branches.
+5. Translate the outline into JSON using the schema below.
+6. Validate your JSON:
+   - Run a JSON formatter or `npm run lint` to catch syntax slips.
+   - Import it in the Mindmapper app (drop the file into the import dialog) and confirm nodes land where you expect.
+7. Summarize what changed in your final message and log any follow-up ideas here if needed.
+
+## JSON schema reminder
+Each mindmap file must follow the structure the app reducer expects:
+
+```json
+{
+  "nodes": [
+    {
+      "id": "string",            // unique per node
+      "parentId": "string|null", // null for root, otherwise parent node id
+      "text": "string",           // short label shown in the map
+      "x": 0,                      // horizontal canvas position in pixels
+      "y": 0,                      // vertical canvas position in pixels
+      "color": "#hex",            // optional; defaults to theme if missing
+      "textSize": "small|medium|large" // optional; defaults to medium
+    }
+  ],
+  "annotations": [],
+  "shapes": []
+}
+```
+
+Tips:
+- Keep coordinates spaced (≈200–300px apart) so branches do not overlap.
+- Colors are optional; pick readable contrasts if you add them.
+- Use `textSize` to emphasize root or summary nodes; keep deeper branches small.
+
+## Testing checklist
+- `npm run lint`
+- `npm run build`
+
+## When updating this folder
+- Describe any new conventions or gotchas in this file so the next agent is ready.
+- If you add helper scripts or assets, explain how to use them.

--- a/AGENTMAPS/AGENTS.MD
+++ b/AGENTMAPS/AGENTS.MD
@@ -1,50 +1,42 @@
-# AGENTMAPS Guide for AI Assistants
+# AGENTMAPS Playbook for AI Assistants
 
-## Purpose
-- Capture mindmaps that teach or document workflows for this project.
-- Keep instructions friendly to non-coders and future agents.
+## Before you start
+- Read `/AGENTS.md` in the repo root so you know the required checks (`npm run lint` and `npm run build`).
+- Skim the existing maps in this folder to match tone, spacing, and color choices.
+- Clarify the map goal with the user. If any detail is fuzzy, list the questions up front so humans can respond.
 
-## Quick workflow
-1. Read `/AGENTS.md` at the repo root for global expectations (lint + build before commit).
-2. Skim existing maps in this folder so new work stays consistent.
-3. Agree with the user on the topic and the level of detail.
-4. Outline the map: pick one root idea, group related thoughts as branches.
-5. Translate the outline into JSON using the schema below.
-6. Validate your JSON:
-   - Run a JSON formatter or `npm run lint` to catch syntax slips.
-   - Import it in the Mindmapper app (drop the file into the import dialog) and confirm nodes land where you expect.
-7. Summarize what changed in your final message and log any follow-up ideas here if needed.
+## How the Mindmapper importer reads JSON
+Each file you create replaces the current canvas. The reducer expects three top-level arrays: `nodes`, `annotations`, and `shapes`. Keep `annotations` and `shapes` present (use `[]` when you do not need them) so the importer never crashes on missing keys.
 
-## JSON schema reminder
-Each mindmap file must follow the structure the app reducer expects:
+Every node in the `nodes` array must include these fields:
+- `id`: unique string. Reuse an id and the later node overwrites the earlier one.
+- `parentId`: `null` for the root node; otherwise match the parent node's id.
+- `text`: short label shown inside the node.
+- `x` and `y`: numbers measured in canvas pixels. The origin `(0, 0)` is the center of the screen.
 
-```json
-{
-  "nodes": [
-    {
-      "id": "string",            // unique per node
-      "parentId": "string|null", // null for root, otherwise parent node id
-      "text": "string",           // short label shown in the map
-      "x": 0,                      // horizontal canvas position in pixels
-      "y": 0,                      // vertical canvas position in pixels
-      "color": "#hex",            // optional; defaults to theme if missing
-      "textSize": "small|medium|large" // optional; defaults to medium
-    }
-  ],
-  "annotations": [],
-  "shapes": []
-}
-```
+Optional styling that the current app honors:
+- `color`: hex string. If you leave it out, the UI applies the default purple.
+- `textSize`: `small`, `medium`, or `large`. The UI normalizes anything else back to `medium`.
 
-Tips:
-- Keep coordinates spaced (≈200–300px apart) so branches do not overlap.
-- Colors are optional; pick readable contrasts if you add them.
-- Use `textSize` to emphasize root or summary nodes; keep deeper branches small.
+## Build a mindmap step by step
+1. **Outline on paper** (or in plain text). Choose one root idea and cluster the supporting ideas into branches.
+2. **Translate to JSON.** Create one object per node. Work from the root outward so you always know each `parentId`.
+3. **Place nodes.** Keep siblings about 200–320 pixels apart (`x` spacing) and step 140–200 pixels down the `y` axis for deeper levels. This mirrors the working sample file below.
+4. **Add styling as needed.** Use bright, readable colors. Reserve `large` text for the root, `medium` for first-level branches, `small` for leaves.
+5. **Check your syntax.** Run a JSON formatter or rely on `npm run lint` (it runs Prettier under the hood) to ensure valid JSON.
+6. **Import locally.** Drag the file into the Mindmapper import dialog. Confirm that:
+   - The root node lands at the center (0,0).
+   - Branches fan out without overlapping.
+   - Colors and text sizes match your intent.
+7. **Document any uncertainties.** If the import reveals odd spacing or behavior, capture it in your final summary so the next agent can adjust quickly.
 
-## Testing checklist
+## Validation checklist before committing
 - `npm run lint`
 - `npm run build`
 
-## When updating this folder
-- Describe any new conventions or gotchas in this file so the next agent is ready.
-- If you add helper scripts or assets, explain how to use them.
+## Sharing updates
+- Summarize the new map (and any open questions) in your final response to the user.
+- If you introduce new conventions or optional helpers, document them here so future agents stay aligned.
+
+## Reference: Minimal working map
+You can import `mindmapper-guide.json` in this folder for a quick visual example. It demonstrates the coordinate spacing, colors, and text sizes discussed above.

--- a/AGENTMAPS/mindmapper-guide.json
+++ b/AGENTMAPS/mindmapper-guide.json
@@ -1,0 +1,87 @@
+{
+  "nodes": [
+    {
+      "id": "root",
+      "parentId": null,
+      "text": "Mindmapper for AI Agents",
+      "x": 0,
+      "y": 0,
+      "color": "#4f46e5",
+      "textSize": "large"
+    },
+    {
+      "id": "understand",
+      "parentId": "root",
+      "text": "Understand the tool",
+      "x": -280,
+      "y": 160,
+      "color": "#22d3ee",
+      "textSize": "medium"
+    },
+    {
+      "id": "understand-read",
+      "parentId": "understand",
+      "text": "Read both AGENTS files",
+      "x": -280,
+      "y": 320,
+      "color": "#38bdf8",
+      "textSize": "small"
+    },
+    {
+      "id": "outline",
+      "parentId": "root",
+      "text": "Outline the branches",
+      "x": 0,
+      "y": 180,
+      "color": "#fbbf24",
+      "textSize": "medium"
+    },
+    {
+      "id": "outline-cluster",
+      "parentId": "outline",
+      "text": "Group related points",
+      "x": 0,
+      "y": 340,
+      "color": "#facc15",
+      "textSize": "small"
+    },
+    {
+      "id": "build",
+      "parentId": "root",
+      "text": "Build JSON nodes",
+      "x": 280,
+      "y": 160,
+      "color": "#f97316",
+      "textSize": "medium"
+    },
+    {
+      "id": "build-fields",
+      "parentId": "build",
+      "text": "Set id, parent, text, x, y",
+      "x": 280,
+      "y": 320,
+      "color": "#fb923c",
+      "textSize": "small"
+    },
+    {
+      "id": "validate",
+      "parentId": "root",
+      "text": "Validate & test",
+      "x": 560,
+      "y": 160,
+      "color": "#10b981",
+      "textSize": "medium"
+    },
+    {
+      "id": "validate-checks",
+      "parentId": "validate",
+      "text": "Run lint + build",
+      "x": 560,
+      "y": 320,
+      "color": "#34d399",
+      "textSize": "small"
+    }
+  ],
+  "annotations": [],
+  "shapes": []
+}

--- a/AGENTMAPS/mindmapper-guide.json
+++ b/AGENTMAPS/mindmapper-guide.json
@@ -3,26 +3,35 @@
     {
       "id": "root",
       "parentId": null,
-      "text": "Mindmapper for AI Agents",
+      "text": "AGENTMAPS Workflow",
       "x": 0,
       "y": 0,
       "color": "#4f46e5",
       "textSize": "large"
     },
     {
-      "id": "understand",
+      "id": "prep",
       "parentId": "root",
-      "text": "Understand the tool",
-      "x": -280,
+      "text": "Prep & context",
+      "x": -320,
       "y": 160,
       "color": "#22d3ee",
       "textSize": "medium"
     },
     {
-      "id": "understand-read",
-      "parentId": "understand",
+      "id": "prep-read",
+      "parentId": "prep",
       "text": "Read both AGENTS files",
-      "x": -280,
+      "x": -320,
+      "y": 320,
+      "color": "#38bdf8",
+      "textSize": "small"
+    },
+    {
+      "id": "prep-questions",
+      "parentId": "prep",
+      "text": "List open questions",
+      "x": -80,
       "y": 320,
       "color": "#38bdf8",
       "textSize": "small"
@@ -30,26 +39,35 @@
     {
       "id": "outline",
       "parentId": "root",
-      "text": "Outline the branches",
-      "x": 0,
-      "y": 180,
-      "color": "#fbbf24",
+      "text": "Outline branches",
+      "x": -80,
+      "y": 160,
+      "color": "#10b981",
       "textSize": "medium"
+    },
+    {
+      "id": "outline-root",
+      "parentId": "outline",
+      "text": "Choose one clear root",
+      "x": -160,
+      "y": 320,
+      "color": "#34d399",
+      "textSize": "small"
     },
     {
       "id": "outline-cluster",
       "parentId": "outline",
-      "text": "Group related points",
-      "x": 0,
-      "y": 340,
-      "color": "#facc15",
+      "text": "Cluster related ideas",
+      "x": 80,
+      "y": 320,
+      "color": "#34d399",
       "textSize": "small"
     },
     {
       "id": "build",
       "parentId": "root",
       "text": "Build JSON nodes",
-      "x": 280,
+      "x": 160,
       "y": 160,
       "color": "#f97316",
       "textSize": "medium"
@@ -57,8 +75,17 @@
     {
       "id": "build-fields",
       "parentId": "build",
-      "text": "Set id, parent, text, x, y",
-      "x": 280,
+      "text": "Set id, parentId, text, x, y",
+      "x": 160,
+      "y": 320,
+      "color": "#fb923c",
+      "textSize": "small"
+    },
+    {
+      "id": "build-style",
+      "parentId": "build",
+      "text": "Optional color & textSize",
+      "x": 400,
       "y": 320,
       "color": "#fb923c",
       "textSize": "small"
@@ -66,19 +93,55 @@
     {
       "id": "validate",
       "parentId": "root",
-      "text": "Validate & test",
-      "x": 560,
+      "text": "Validate & import",
+      "x": 400,
       "y": 160,
-      "color": "#10b981",
+      "color": "#0ea5e9",
       "textSize": "medium"
+    },
+    {
+      "id": "validate-import",
+      "parentId": "validate",
+      "text": "Drop JSON into importer",
+      "x": 400,
+      "y": 320,
+      "color": "#38bdf8",
+      "textSize": "small"
     },
     {
       "id": "validate-checks",
       "parentId": "validate",
-      "text": "Run lint + build",
-      "x": 560,
+      "text": "Run npm run lint & build",
+      "x": 640,
       "y": 320,
-      "color": "#34d399",
+      "color": "#38bdf8",
+      "textSize": "small"
+    },
+    {
+      "id": "iterate",
+      "parentId": "root",
+      "text": "Iterate & report",
+      "x": 640,
+      "y": 160,
+      "color": "#ef4444",
+      "textSize": "medium"
+    },
+    {
+      "id": "iterate-feedback",
+      "parentId": "iterate",
+      "text": "Log feedback for humans",
+      "x": 880,
+      "y": 320,
+      "color": "#f87171",
+      "textSize": "small"
+    },
+    {
+      "id": "iterate-summary",
+      "parentId": "iterate",
+      "text": "Summarize changes in handoff",
+      "x": 1120,
+      "y": 320,
+      "color": "#f87171",
       "textSize": "small"
     }
   ],


### PR DESCRIPTION
## Summary
- add AGENTMAPS/AGENTS.MD with workflow and schema guidance for AI assistants creating mindmaps
- add AGENTMAPS/mindmapper-guide.json as an importable visualization of the workflow

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd87d3d2e4832b87e465cbbddf6a42