### PR TITLE
Refresh documentation for contributors and agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,36 @@
-# AGENTS
+# Mindmapper Agent Guide
 
-## Required checks
-- Run `npm run lint` before committing.
-- Run `npm run build` before committing.
+## Start here
+- Skim `README.md` for the product tour, feature list, and data model overview.
+- Read `AGENTMAPS/AGENTS.MD` before editing or generating map JSON. It explains how the importer expects nodes, annotations, and shapes to be structured and includes a working sample.
+- Share open questions early. If a requirement is unclear, restate it in your own words and list the follow-up questions so humans can respond quickly.
 
-## Style notes
-- Keep explanations and inline comments in clear, plain English so non-developers can follow along.
+## Required checks (run before every commit)
+1. `npm run lint`
+2. `npm run build`
 
-## Features in progress
-- Shape tools now include rings and ellipses that use a golden resize handle. Follow the same interaction pattern when you introduce more shapes.
-- Nodes and floating text boxes now store a `textSize` of `small`, `medium`, or `large`. Use the shared `normalizeTextSize` helper when adding new entry points that create or import these records.
-- The top toolbar is now collapsible; keep creation buttons available when collapsed and tuck detailed controls inside the expanded panel.
-- The toolbar now has a single text editor that updates whichever node or text box is selected. Follow the `selectedTextTarget` pattern when wiring future text-based controls.
-- Double-clicking any node or floating text box should pop the toolbar open and move focus to the shared text editor so users can type right away.
+These commands validate syntax, formatting, types, and bundling. Rerun them after each change until they pass.
+
+## Local workflow
+1. Install dependencies with `npm install`.
+2. Start the dev server (`npm run dev`) to confirm UX flows such as node editing, shape handles, import/export, and zoom controls.
+3. Keep explanations, inline comments, and commit messages in plain English so non-developers can follow the changes.
+4. Describe what someone should see when they test locally (for example, "Running `npm run dev` shows the updated toolbar labels").
+
+## Collaboration tips
+- Document new conventions (UI tweaks, data shapes, helper utilities) directly in the scoped `AGENTS.MD` file so future agents inherit the context.
+- Prefer enhancing existing patterns instead of adding parallel solutions. Reuse helpers like `normalizeTextSize`, the shared toolbar text editor, and the `selectedTextTarget` pattern.
+- When expanding shape tools, match the golden resize handle interaction already used by rings and ellipses.
+- Keep node and text box edits wired through the shared toolbar so double-click-to-edit continues to work.
+
+## Features to keep in mind
+- Shape tools now include rings, ellipses, rectangles, arrows, and lines that rely on a single golden resize handle.
+- Nodes and floating text boxes store a `textSize` of `small`, `medium`, or `large`. Always pass values through `normalizeTextSize` when creating or importing records.
+- The top toolbar collapses. Leave creation buttons visible when collapsed and tuck detailed controls into the expanded panel.
+- The toolbar hosts one text editor that updates whichever node, annotation, or shape label is selected. Follow the `selectedTextTarget` logic when adding text-based controls.
+- Double-clicking any node or floating text box should pop the toolbar open and move focus to the shared text editor so users can type immediately.
+
+## Shipping checklist
+- Update documentation (including `README.md` or scoped guides) whenever you add capabilities or conventions that other agents must know.
+- Summarize changes, test results, and any remaining questions in your final message to the user.
+- Leave the repository clean (`git status` should report no pending changes) before wrapping up.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,73 @@
-# Mindmapper React Canvas Seed
+# Mindmapper
 
-This branch starts the React rewrite of Mindmapper with the smallest possible feature set. The app renders a full-screen canvas
-and draws an interactive mind map so we can verify rendering, resizing, and device pixel ratio handling.
+Mindmapper is a React + canvas app for sketching mind maps directly in the browser. The UI focuses on quick idea capture, smooth navigation, and easy ways to export or share your map.
 
-## What works right now
-- Drag any node to reposition it; connectors redraw automatically.
-- Use the floating toolbar to add children, delete the active node (except the root), and undo/redo.
-- Keyboard shortcuts mirror the toolbar: `Enter` adds a child, `Delete`/`Backspace` removes the selection, `Ctrl/Cmd+Z` undoes,
-  and `Ctrl/Cmd+Y` (or `Shift+Ctrl/Cmd+Z`) redoes.
-- The app auto-saves to your browser. Refreshing the dev server restores the last map you edited.
-- Toolbar buttons now let you export a JSON snapshot, re-import a saved file, or download the current canvas as a PNG.
+## What you can do today
+- **Grow ideas visually.** Drag nodes, add children with the toolbar or keyboard (`Enter`), and remove them with `Delete` / `Backspace`. Connectors redraw automatically as you move items.
+- **Format content from one toolbar.** A single text editor and size dropdown updates whichever node, floating annotation, or shape label is selected. Double-clicking a node opens the toolbar and moves focus into the text field so you can keep typing.
+- **Drop in callouts and shapes.** Place floating annotations, rings, ellipses, rectangles, arrows, and lines. Each shape has a golden resize handle that controls thickness, size, and angle (for arrows and lines).
+- **Control the canvas.** Pan with the arrow keys or on-screen D-pad, zoom between 25% and 250%, auto-center the map, toggle light/dark canvas backgrounds, and lock the canvas to prevent accidental edits.
+- **Manage revisions.** Undo/redo stacks let you retrace steps. `Clear` resets the canvas back to the single root node.
+- **Import and export data.** Save your work as JSON (editable), PNG (image snapshot), or PDF (vector-friendly). Importing a JSON file replaces the current map. The app also auto-saves to `localStorage` so a browser refresh restores your latest state.
 
+## Quick start
+1. **Install dependencies** (Node.js 18+ and npm 9+ recommended):
+   ```bash
+   npm install
+   ```
+2. **Run the dev server**:
+   ```bash
+   npm run dev
+   ```
+   Vite prints a local URL (defaults to `http://localhost:5173`). Opening it shows the canvas with a purple root node at the center. Drag it around, press `Enter` to spawn children, and try the toolbar buttons to add shapes or undo your changes.
+3. **Preview a production build** (optional):
+   ```bash
+   npm run build
+   npm run preview
+   ```
+   `npm run build` compiles TypeScript and bundles the app. `npm run preview` serves the generated build so you can confirm nothing breaks outside the dev server.
 
-## Prerequisites
-- Node.js 18+
-- npm 9+
+## Scripts
+- `npm run dev` – Start the Vite dev server with hot reloading.
+- `npm run lint` – Run ESLint (with Prettier rules) across the project. Use this before every commit to catch syntax and formatting issues.
+- `npm run build` – Type-check the project and emit a production bundle.
+- `npm run preview` – Serve the latest production bundle locally.
 
-## Install and run locally
-```bash
-npm install
-npm run dev
+## Project layout
+- `src/App.tsx` – The main React component. It renders the canvas, toolbar, navigation controls, and import/export workflow. Interaction helpers for nodes, annotations, and shapes live here.
+- `src/state/MindMapContext.tsx` – Global state container. It defines the mind map data model, reducer actions (add/move/delete, undo/redo, import/export), and local storage persistence.
+- `src/utils/pdf.ts` – Builds a lightweight PDF stream so we can export maps without a heavy dependency.
+- `AGENTMAPS/` – Reference JSON maps and guidance for assistants who want to script their own diagrams. Start with `AGENTMAPS/AGENTS.MD` to learn the required data structure and workflow.
+- `public/`, `index.html`, and `vite.config.ts` – Standard Vite scaffolding.
+
+## Data model at a glance
+The importer expects three arrays in every snapshot:
+
+```ts
+{
+  nodes: MindMapNode[]
+  annotations: MindMapAnnotation[]
+  shapes: MindMapShape[]
+}
 ```
-The dev server prints a local URL (default `http://localhost:5173`). Open it to drag the purple root node, spawn children, and use the toolbar or shortcuts to undo, redo, or delete nodes. Resize the window to confirm the canvas remains responsive.
 
-### Export and import helpers
-- **Export JSON** downloads a machine-readable snapshot of every node in the current map.
-- **Import JSON** accepts a previously exported file and replaces the current map contents with it.
-- **Export PNG** saves an image of the current canvas view so you can share quick diagrams.
+Each node records its unique `id`, the `parentId` (use `null` for the root), display `text`, position (`x`, `y` in canvas pixels, with the origin in the center), a `color`, and a `textSize` (`small`, `medium`, or `large`).
 
-Every change is also stored in `localStorage`, so reloading the page brings back the latest map without needing to import.
+Annotations store `id`, `text`, `x`, `y`, and `textSize` so they can float independently of the node tree.
 
-## Build for production
-```bash
-npm run build
-```
+Shapes cover rings, ellipses, rectangles, arrows, and lines. Every shape includes an `id`, `kind`, center coordinates (`x`, `y`), and size fields specific to the shape (for example `radius` for rings, `width`/`height` for rectangles). Thickness and `color` let you style them. Optional angle fields control rotation where relevant.
+
+Review `AGENTMAPS/mindmapper-guide.json` for a working example that matches what the importer expects.
+
+## Tips for contributors and AI agents
+- Read `AGENTS.md` (repo root) for required checks and collaboration norms. It links to deeper guides, including the AGENTMAPS playbook.
+- Use the toolbar’s lock toggle before presenting a map to avoid accidental edits.
+- When you add new shapes or text entry points, reuse helpers like `normalizeTextSize` so imports and UI interactions stay in sync.
+- Document any new conventions or UX tweaks in `AGENTS.md` or the relevant folder’s guide so future collaborators stay aligned.
+
+## Testing and QA expectations
+- Run `npm run lint` and `npm run build` before opening a pull request. They catch syntax issues, type errors, and bundling regressions.
+- Manual QA: launch `npm run dev`, import/export a JSON map from `AGENTMAPS/`, and confirm the canvas responds to panning, zooming, and undo/redo.
+
+## Need a ready-made map?
+The `AGENTMAPS` folder contains shareable JSON files and a playbook tailored to AI assistants. Import `AGENTMAPS/mindmapper-guide.json` through the toolbar to see a complete, spaced-out map. Use that structure as the starting point when authoring new diagrams.


### PR DESCRIPTION
## Summary
- rewrite README to highlight current features, project layout, and the AGENTMAPS learning resources
- reorganize AGENTS.md so assistants start with the README, follow AGENTMAPS guidance, and understand collaboration norms

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd9d975648832b811990eaaf23a7b7