### PR TITLE
Add keyboard shortcut overlay and new commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ These commands validate syntax, formatting, types, and bundling. Rerun them afte
 - Shape tools now include rings, ellipses, rectangles, arrows, and lines that rely on a single golden resize handle.
 - Nodes and floating text boxes store a `textSize` of `small`, `medium`, or `large`. Always pass values through `normalizeTextSize` when creating or importing records.
 - Nodes expose color swatches in the toolbar. Use `DEFAULT_NODE_COLOR`, `NODE_COLOR_OPTIONS`, and dispatch `UPDATE_NODES` so single and multi-select color changes land in one history entry.
+- Keyboard shortcuts now include Space (or C) to recentre the view and Shift+Enter to add a detached idea. Keep the shortcut list in `KEYBOARD_SHORTCUTS` (App.tsx) in sync when you add or remove shortcuts so the in-app cheat sheet stays accurate.
 - Selection now tracks an ordered array. Shift or Meta/Ctrl-click toggles membership, batch reducers like `MOVE_NODES`, `DELETE_NODES`, and `UPDATE_NODES` keep history tidy, and the first id in the array is the "primary" node when a single target is required.
 - Copy/Paste is wired through `handleCopyNodes` / `handlePasteNodes` in `App.tsx`. The `ADD_NODES` reducer clones every selected node into new top-level entries, offsets them slightly, and keeps the whole paste in a single undo step. Buttons live in the bottom-left command panel alongside Ctrl/Cmd+C and Ctrl/Cmd+V shortcuts.
 - Circular node labels now wrap into multiple centered lines. Reuse `measureNodeLabel`/`calculateNodeLabelLayout` to keep padding and radius calculations in sync with the wrapped text.

--- a/src/App.css
+++ b/src/App.css
@@ -225,6 +225,66 @@
   cursor: not-allowed;
 }
 
+.mindmap-shortcuts {
+  position: relative;
+  display: flex;
+}
+
+.mindmap-shortcuts__menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.55);
+  min-width: 18rem;
+  max-width: clamp(18rem, 32vw, 24rem);
+  z-index: 10;
+}
+
+.mindmap-shortcuts__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #facc15;
+}
+
+.mindmap-shortcuts__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.mindmap-shortcuts__item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: 0.75rem;
+  background: rgba(30, 41, 59, 0.65);
+}
+
+.mindmap-shortcuts__keys {
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: #facc15;
+}
+
+.mindmap-shortcuts__description {
+  font-size: 0.85rem;
+  color: #e2e8f0;
+  line-height: 1.35;
+}
+
 .mindmap-toolbar__text-editor {
   display: flex;
   flex-direction: column;

--- a/src/App.css
+++ b/src/App.css
@@ -261,6 +261,8 @@
   padding: 0;
   margin: 0;
   list-style: none;
+  max-height: 21rem;
+  overflow-y: auto;
 }
 
 .mindmap-shortcuts__item {


### PR DESCRIPTION
## Summary
- add a shortcuts button beside import/export that shows a full list of key commands
- support spacebar recentering and Shift+Enter detached ideas across the app and text editor
- document the new shortcuts for future contributors

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d30004aab4832b95e3fcaf428a5ecd