### PR TITLE
Simplify creation controls and collapse edit panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -91,10 +91,19 @@
   line-height: 1;
 }
 
+.mindmap-toolbar__symbol--detached {
+  color: #0f172a;
+}
+
+.mindmap-toolbar__symbol--child {
+  color: #1f2937;
+}
+
 .mindmap-toolbar__symbol--text {
   font-size: 0.9rem;
   letter-spacing: 0.04em;
   text-transform: lowercase;
+  color: #374151;
 }
 
 .mindmap-toolbar button:hover {
@@ -544,7 +553,12 @@
 }
 
 .mindmap-actions--collapsed {
-  padding: 0.75rem 0.85rem;
+  padding: 0.55rem 0.7rem;
+  gap: 0;
+}
+
+.mindmap-actions--collapsed .mindmap-actions__body {
+  display: none;
 }
 
 .mindmap-actions__row {

--- a/src/App.css
+++ b/src/App.css
@@ -69,10 +69,32 @@
   min-width: 2.6rem;
 }
 
+.mindmap-toolbar button.mindmap-toolbar__symbol-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem;
+  width: 2.6rem;
+  height: 2.6rem;
+  min-width: 2.6rem;
+}
+
 .mindmap-toolbar__icon {
   display: block;
   width: 1.6rem;
   height: 1.6rem;
+}
+
+.mindmap-toolbar__symbol {
+  font-size: 1.35rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.mindmap-toolbar__symbol--text {
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
 }
 
 .mindmap-toolbar button:hover {
@@ -495,6 +517,34 @@
   backdrop-filter: blur(12px);
   box-shadow: 0 18px 40px rgba(76, 29, 149, 0.45);
   z-index: 5;
+}
+
+.mindmap-actions__header {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.mindmap-actions__collapse-button {
+  flex: 0 0 auto;
+  width: 2.4rem;
+  min-width: 2.4rem;
+  height: 2.4rem;
+  padding: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.mindmap-actions__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mindmap-actions--collapsed {
+  padding: 0.75rem 0.85rem;
 }
 
 .mindmap-actions__row {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3326,7 +3326,12 @@ export default function App() {
               className="mindmap-toolbar__symbol-button"
               disabled={isLocked}
             >
-              <span aria-hidden="true" className="mindmap-toolbar__symbol">×</span>
+              <span
+                aria-hidden="true"
+                className="mindmap-toolbar__symbol mindmap-toolbar__symbol--detached"
+              >
+                ×
+              </span>
               <span className="visually-hidden">Add new idea</span>
             </button>
             <button
@@ -3337,7 +3342,12 @@ export default function App() {
               className="mindmap-toolbar__symbol-button"
               disabled={isLocked}
             >
-              <span aria-hidden="true" className="mindmap-toolbar__symbol">+</span>
+              <span
+                aria-hidden="true"
+                className="mindmap-toolbar__symbol mindmap-toolbar__symbol--child"
+              >
+                +
+              </span>
               <span className="visually-hidden">Add child idea</span>
             </button>
             <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -673,6 +673,7 @@ export default function App() {
   const [isShortcutsOpen, setShortcutsOpen] = useState(false)
   const [shortcutsVisibleHeight, setShortcutsVisibleHeight] = useState<number | null>(null)
   const [isToolbarCollapsed, setToolbarCollapsed] = useState(false)
+  const [areActionsCollapsed, setActionsCollapsed] = useState(false)
   const [isLocked, setIsLocked] = useState(false)
   const [backgroundTheme, setBackgroundTheme] = useState<'dark' | 'light'>('dark')
 
@@ -870,6 +871,10 @@ export default function App() {
 
   const toggleToolbarCollapsed = useCallback(() => {
     setToolbarCollapsed((previous) => !previous)
+  }, [])
+
+  const toggleActionsCollapsed = useCallback(() => {
+    setActionsCollapsed((previous) => !previous)
   }, [])
 
   const toggleLock = useCallback(() => {
@@ -3247,7 +3252,9 @@ export default function App() {
 
   const toolbarBodyId = 'mindmap-toolbar-body'
   const shortcutsMenuId = 'mindmap-shortcuts-menu'
+  const actionsBodyId = 'mindmap-actions-body'
   const toolbarClassName = `mindmap-toolbar${isToolbarCollapsed ? ' mindmap-toolbar--collapsed' : ''}`
+  const actionsClassName = `mindmap-actions${areActionsCollapsed ? ' mindmap-actions--collapsed' : ''}`
   const appShellClassName = `app-shell app-shell--${backgroundTheme}`
   const isEditingNode = selectedTextTarget?.kind === 'node'
   const isEditingAnnotation = selectedTextTarget?.kind === 'annotation'
@@ -3286,10 +3293,13 @@ export default function App() {
   const lockButtonIcon = isLocked ? '🔒' : '🔓'
   const isDarkBackground = backgroundTheme === 'dark'
   const backgroundButtonLabel = isDarkBackground ? 'Dark background' : 'Light background'
-  const backgroundButtonIcon = isDarkBackground ? '🌙' : '☀️'
+  const backgroundButtonIcon = isDarkBackground ? '🌑' : '☀️'
   const backgroundButtonTitle = isDarkBackground
     ? 'Switch to a bright background'
     : 'Switch to a deep background'
+  const actionsToggleIcon = areActionsCollapsed ? '▴' : '▾'
+  const actionsToggleTitle = areActionsCollapsed ? 'Show edit commands' : 'Hide edit commands'
+  const actionsToggleLabel = areActionsCollapsed ? 'Expand edit commands' : 'Collapse edit commands'
 
   return (
     <div className={appShellClassName}>
@@ -3312,25 +3322,34 @@ export default function App() {
               type="button"
               onClick={handleAddStandaloneNode}
               title="Shift + Enter to add a new detached idea"
+              aria-label="Add new idea"
+              className="mindmap-toolbar__symbol-button"
               disabled={isLocked}
             >
-              Add idea
+              <span aria-hidden="true" className="mindmap-toolbar__symbol">×</span>
+              <span className="visually-hidden">Add new idea</span>
             </button>
             <button
               type="button"
               onClick={handleAddChild}
               title="Enter to add a child idea"
+              aria-label="Add child idea"
+              className="mindmap-toolbar__symbol-button"
               disabled={isLocked}
             >
-              Add child
+              <span aria-hidden="true" className="mindmap-toolbar__symbol">+</span>
+              <span className="visually-hidden">Add child idea</span>
             </button>
             <button
               type="button"
               onClick={handleAddAnnotation}
               title="Add a floating text box"
+              aria-label="Add textbox"
+              className="mindmap-toolbar__symbol-button"
               disabled={isLocked}
             >
-              Textbox
+              <span aria-hidden="true" className="mindmap-toolbar__symbol mindmap-toolbar__symbol--text">abc</span>
+              <span className="visually-hidden">Add textbox</span>
             </button>
             <button
               type="button"
@@ -3578,81 +3597,96 @@ export default function App() {
           onChange={handleFileChange}
         />
       </div>
-      <div className="mindmap-actions" role="group" aria-label="Edit commands">
-        <div className="mindmap-actions__row">
+      <div className={actionsClassName} role="group" aria-label="Edit commands">
+        <div className="mindmap-actions__header">
           <button
             type="button"
-            onClick={toggleLock}
-            aria-pressed={isLocked}
-            title={lockButtonTitle}
+            onClick={toggleActionsCollapsed}
+            className="mindmap-actions__collapse-button"
+            aria-expanded={!areActionsCollapsed}
+            aria-controls={actionsBodyId}
+            title={actionsToggleTitle}
           >
-            <span aria-hidden="true" className="mindmap-actions__icon">{lockButtonIcon}</span>
-            <span className="visually-hidden">{lockButtonLabel}</span>
-          </button>
-          <button
-            type="button"
-            onClick={toggleBackgroundTheme}
-            aria-pressed={isDarkBackground}
-            aria-label={backgroundButtonTitle}
-            title={backgroundButtonTitle}
-          >
-            <span aria-hidden="true" className="mindmap-actions__icon">{backgroundButtonIcon}</span>
-            <span className="visually-hidden">{backgroundButtonLabel}</span>
+            <span aria-hidden="true">{actionsToggleIcon}</span>
+            <span className="visually-hidden">{actionsToggleLabel}</span>
           </button>
         </div>
-        <div className="mindmap-actions__row">
-          <button
-            type="button"
-            onClick={handleDeleteSelection}
-            disabled={isLocked || !canDelete}
-            title="Delete or Backspace"
-          >
-            Delete
-          </button>
-          <button
-            type="button"
-            onClick={handleClearAll}
-            disabled={isLocked || !canClear}
-            title="Reset the canvas to a fresh root node"
-          >
-            Clear
-          </button>
-        </div>
-        <div className="mindmap-actions__row">
-          <button
-            type="button"
-            onClick={handleCopyNodes}
-            disabled={!canCopyNodes}
-            title={copyButtonTitle}
-          >
-            Copy
-          </button>
-          <button
-            type="button"
-            onClick={handlePasteNodes}
-            disabled={!canPasteNodes}
-            title={pasteButtonTitle}
-          >
-            Paste
-          </button>
-        </div>
-        <div className="mindmap-actions__row">
-          <button
-            type="button"
-            onClick={handleUndo}
-            disabled={isLocked || !canUndo}
-            title="Ctrl/Cmd + Z"
-          >
-            Undo
-          </button>
-          <button
-            type="button"
-            onClick={handleRedo}
-            disabled={isLocked || !canRedo}
-            title="Ctrl/Cmd + Shift + Z"
-          >
-            Redo
-          </button>
+        <div id={actionsBodyId} className="mindmap-actions__body" hidden={areActionsCollapsed}>
+          <div className="mindmap-actions__row">
+            <button
+              type="button"
+              onClick={toggleLock}
+              aria-pressed={isLocked}
+              title={lockButtonTitle}
+            >
+              <span aria-hidden="true" className="mindmap-actions__icon">{lockButtonIcon}</span>
+              <span className="visually-hidden">{lockButtonLabel}</span>
+            </button>
+            <button
+              type="button"
+              onClick={toggleBackgroundTheme}
+              aria-pressed={isDarkBackground}
+              aria-label={backgroundButtonTitle}
+              title={backgroundButtonTitle}
+            >
+              <span aria-hidden="true" className="mindmap-actions__icon">{backgroundButtonIcon}</span>
+              <span className="visually-hidden">{backgroundButtonLabel}</span>
+            </button>
+          </div>
+          <div className="mindmap-actions__row">
+            <button
+              type="button"
+              onClick={handleDeleteSelection}
+              disabled={isLocked || !canDelete}
+              title="Delete or Backspace"
+            >
+              Delete
+            </button>
+            <button
+              type="button"
+              onClick={handleClearAll}
+              disabled={isLocked || !canClear}
+              title="Reset the canvas to a fresh root node"
+            >
+              Clear
+            </button>
+          </div>
+          <div className="mindmap-actions__row">
+            <button
+              type="button"
+              onClick={handleCopyNodes}
+              disabled={!canCopyNodes}
+              title={copyButtonTitle}
+            >
+              Copy
+            </button>
+            <button
+              type="button"
+              onClick={handlePasteNodes}
+              disabled={!canPasteNodes}
+              title={pasteButtonTitle}
+            >
+              Paste
+            </button>
+          </div>
+          <div className="mindmap-actions__row">
+            <button
+              type="button"
+              onClick={handleUndo}
+              disabled={isLocked || !canUndo}
+              title="Ctrl/Cmd + Z"
+            >
+              Undo
+            </button>
+            <button
+              type="button"
+              onClick={handleRedo}
+              disabled={isLocked || !canRedo}
+              title="Ctrl/Cmd + Shift + Z"
+            >
+              Redo
+            </button>
+          </div>
         </div>
       </div>
       <div className="mindmap-navigation" role="group" aria-label="Viewport navigation controls">


### PR DESCRIPTION
## Summary
- replace the top toolbar text buttons for add idea, add child, and textbox with icon-style symbols while keeping accessible labels
- add a collapse/expand toggle to the bottom-left edit panel and swap in a dark moon icon when the dark background is active
- style the new symbol buttons and collapse control so they match the existing interface

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d40f625e5c832b93db87cda9a0b001