### PR TITLE
Add curved cross-link support between nodes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ These commands validate syntax, formatting, types, and bundling. Rerun them afte
 
 ## Features to keep in mind
 - Shape tools now include rings, ellipses, rectangles, arrows, and lines that rely on a single golden resize handle.
+- Cross-links connect any two nodes. They live in `state.crossLinks`, export with the map JSON, and render as curved connectors that arc around nearby nodes.
 - Nodes and floating text boxes store a `textSize` of `small`, `medium`, or `large`. Always pass values through `normalizeTextSize` when creating or importing records.
 - Nodes expose color swatches in the toolbar. Use `DEFAULT_NODE_COLOR`, `NODE_COLOR_OPTIONS`, and dispatch `UPDATE_NODES` so single and multi-select color changes land in one history entry.
 - Keyboard shortcuts now include Space (or C) to recentre the view and Shift+Enter to add a detached idea. Keep the shortcut list in `KEYBOARD_SHORTCUTS` (App.tsx) in sync when you add or remove shortcuts so the in-app cheat sheet stays accurate.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Mindmapper is a React + canvas app for sketching mind maps directly in the brows
 
 ## What you can do today
 - **Grow ideas visually.** Drag nodes, add children with the toolbar or keyboard (`Enter`), and remove them with `Delete` / `Backspace`. Connectors redraw automatically as you move items.
+- **Connect ideas beyond the tree.** Multi-select any two nodes and tap the curved link button to add a cross-link. The app curves the connector around nearby nodes so lateral relationships stay readable.
 - **Format content from one toolbar.** A single text editor and size dropdown updates whichever node, floating annotation, or shape label is selected. Double-clicking a node opens the toolbar and moves focus into the text field so you can keep typing.
 - **Drop in callouts and shapes.** Place floating annotations, rings, ellipses, rectangles, arrows, and lines. Each shape has a golden resize handle that controls thickness, size, and angle (for arrows and lines).
 - **Control the canvas.** Pan with the arrow keys or on-screen D-pad, zoom between 25% and 250%, auto-center the map, toggle light/dark canvas backgrounds, and lock the canvas to prevent accidental edits.
@@ -48,6 +49,7 @@ The importer expects three arrays in every snapshot:
   nodes: MindMapNode[]
   annotations: MindMapAnnotation[]
   shapes: MindMapShape[]
+  crossLinks: MindMapCrossLink[]
 }
 ```
 
@@ -56,6 +58,8 @@ Each node records its unique `id`, the `parentId` (use `null` for the root), dis
 Annotations store `id`, `text`, `x`, `y`, and `textSize` so they can float independently of the node tree.
 
 Shapes cover rings, ellipses, rectangles, arrows, and lines. Every shape includes an `id`, `kind`, center coordinates (`x`, `y`), and size fields specific to the shape (for example `radius` for rings, `width`/`height` for rectangles). Thickness and `color` let you style them. Optional angle fields control rotation where relevant.
+
+Cross-links capture lateral connections between ideas. Each record stores an `id`, the `sourceId` and `targetId` (node ids), and the canvas automatically curves the link between the two when rendering.
 
 Review `AGENTMAPS/mindmapper-guide.json` for a working example that matches what the importer expects.
 

--- a/src/App.css
+++ b/src/App.css
@@ -99,6 +99,11 @@
   color: #1f2937;
 }
 
+.mindmap-toolbar__symbol--cross-link {
+  color: #0ea5e9;
+  font-size: 1.2rem;
+}
+
 .mindmap-toolbar__symbol--text {
   font-size: 0.9rem;
   letter-spacing: 0.04em;


### PR DESCRIPTION
## Summary
- add a cross-link model to mind map state, history, and persistence
- render curved cross-links on the canvas and add a toolbar button to create or remove them between selected nodes
- include cross-links in import/export payloads and document the feature for future contributors

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d41be12fb0832b8e6e7c92d43e31c7