### PR TITLE
Adjust toolbar actions and text editor layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -330,6 +330,8 @@
   padding: 0.45rem 0.7rem;
   border-radius: 1rem;
   background: rgba(15, 23, 42, 0.55);
+  align-self: flex-start;
+  width: min(100%, 22rem);
 }
 
 .mindmap-toolbar__text-control {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3559,22 +3559,6 @@ export default function App() {
           <div className="mindmap-toolbar__header-actions">
             <button
               type="button"
-              onClick={handleAddStandaloneNode}
-              title="Shift + Enter to add a new detached idea"
-              aria-label="Add new idea"
-              className="mindmap-toolbar__symbol-button"
-              disabled={isLocked}
-            >
-              <span
-                aria-hidden="true"
-                className="mindmap-toolbar__symbol mindmap-toolbar__symbol--detached"
-              >
-                ×
-              </span>
-              <span className="visually-hidden">Add new idea</span>
-            </button>
-            <button
-              type="button"
               onClick={handleAddChild}
               title="Enter to add a child idea"
               aria-label="Add child idea"
@@ -3588,6 +3572,22 @@ export default function App() {
                 +
               </span>
               <span className="visually-hidden">Add child idea</span>
+            </button>
+            <button
+              type="button"
+              onClick={handleAddStandaloneNode}
+              title="Shift + Enter to add a new detached idea"
+              aria-label="Add new idea"
+              className="mindmap-toolbar__symbol-button"
+              disabled={isLocked}
+            >
+              <span
+                aria-hidden="true"
+                className="mindmap-toolbar__symbol mindmap-toolbar__symbol--detached"
+              >
+                ×
+              </span>
+              <span className="visually-hidden">Add new idea</span>
             </button>
             <button
               type="button"


### PR DESCRIPTION
## Summary
- move the add child button ahead of the detached idea control in the toolbar header
- cap the toolbar text editor container width so the inputs align with the icon row

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d422a0d440832baba68efa5fae29c9