### PR TITLE
Reorder toolbar buttons and tighten layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,7 +36,8 @@
   color: #f8fafc;
   backdrop-filter: blur(12px);
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
-  width: min(44rem, calc(100vw - 2.5rem));
+  width: auto;
+  max-width: min(46rem, calc(100vw - 2.5rem));
   z-index: 5;
 }
 
@@ -139,6 +140,7 @@
   gap: 0.5rem;
   flex-wrap: nowrap;
   overflow-x: auto;
+  width: 100%;
 }
 
 .mindmap-toolbar__header-actions {
@@ -146,7 +148,7 @@
   align-items: center;
   gap: 0.4rem;
   flex-wrap: nowrap;
-  flex: 1 0 auto;
+  flex: 1 1 auto;
 }
 
 .mindmap-toolbar__toggle {
@@ -327,9 +329,10 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding: 0.45rem 0.7rem;
+  padding: 0.45rem 0.75rem 0.55rem;
   border-radius: 1rem;
   background: rgba(15, 23, 42, 0.55);
+  width: 100%;
 }
 
 .mindmap-toolbar__text-control {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3559,22 +3559,6 @@ export default function App() {
           <div className="mindmap-toolbar__header-actions">
             <button
               type="button"
-              onClick={handleAddStandaloneNode}
-              title="Shift + Enter to add a new detached idea"
-              aria-label="Add new idea"
-              className="mindmap-toolbar__symbol-button"
-              disabled={isLocked}
-            >
-              <span
-                aria-hidden="true"
-                className="mindmap-toolbar__symbol mindmap-toolbar__symbol--detached"
-              >
-                ×
-              </span>
-              <span className="visually-hidden">Add new idea</span>
-            </button>
-            <button
-              type="button"
               onClick={handleAddChild}
               title="Enter to add a child idea"
               aria-label="Add child idea"
@@ -3588,6 +3572,22 @@ export default function App() {
                 +
               </span>
               <span className="visually-hidden">Add child idea</span>
+            </button>
+            <button
+              type="button"
+              onClick={handleAddStandaloneNode}
+              title="Shift + Enter to add a new detached idea"
+              aria-label="Add new idea"
+              className="mindmap-toolbar__symbol-button"
+              disabled={isLocked}
+            >
+              <span
+                aria-hidden="true"
+                className="mindmap-toolbar__symbol mindmap-toolbar__symbol--detached"
+              >
+                ×
+              </span>
+              <span className="visually-hidden">Add new idea</span>
             </button>
             <button
               type="button"


### PR DESCRIPTION
## Summary
- move the child idea (+) control ahead of the detached idea (×) button so the toolbar order matches the expected workflow
- let the toolbar shrink to the actual content width and stretch the editor panel so text, size, and color controls line up with the button row

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d560436f28832b8f889db7e4606938